### PR TITLE
Add React Testing Library tests for all components and pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ npm-debug.log*
 
 # Claude Code
 .claude/
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 
 ### Branching
 - Always create a feature branch before starting any new major feature
+- Always branch directly from `main` — no chaining branches off other feature branches
 - Never commit directly to `main`
 - Branch naming convention: `feature/description` (e.g., `feature/course-listing`, `feature/quiz-page`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "temp-app",
+  "name": "medicode-institute",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp-app",
+      "name": "medicode-institute",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,13 @@
       "last 1 safari version"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router$": "<rootDir>/node_modules/react-router/dist/development/index.js",
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
+    }
+  },
   "devDependencies": {
     "@types/styled-components": "^5.1.36"
   }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import App from './App';
+
+describe('App', () => {
+  it('renders Navbar on every page', async () => {
+    render(<App />);
+    expect(screen.getByLabelText('Toggle menu')).toBeInTheDocument();
+  });
+
+  it('renders Footer on every page', async () => {
+    render(<App />);
+    expect(screen.getByText(/MediCode Institute. All rights reserved/)).toBeInTheDocument();
+  });
+
+  it('renders Home page on "/" route', async () => {
+    window.history.pushState({}, '', '/');
+    render(<App />);
+    expect(await screen.findByText('Bridge Medicine & Technology')).toBeInTheDocument();
+  });
+
+  it('renders Courses page on "/courses" route', async () => {
+    window.history.pushState({}, '', '/courses');
+    render(<App />);
+    expect(await screen.findByRole('heading', { name: 'All Courses' })).toBeInTheDocument();
+  });
+
+  it('renders About page on "/about" route', async () => {
+    window.history.pushState({}, '', '/about');
+    render(<App />);
+    expect(await screen.findByText('About MediCode Institute')).toBeInTheDocument();
+  });
+
+  it('renders NotFound page on unknown route', async () => {
+    window.history.pushState({}, '', '/nonexistent');
+    render(<App />);
+    expect(await screen.findByText('404')).toBeInTheDocument();
+  });
+
+  it('renders Quiz page on "/quiz" route', async () => {
+    window.history.pushState({}, '', '/quiz');
+    render(<App />);
+    expect(await screen.findByText('Practice Quizzes')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/Button/Button.test.tsx
+++ b/src/components/common/Button/Button.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from 'test-utils';
+import userEvent from '@testing-library/user-event';
+import Button from './index';
+
+describe('Button', () => {
+  it('renders children text', () => {
+    render(<Button>Click Me</Button>);
+    expect(screen.getByText('Click Me')).toBeInTheDocument();
+  });
+
+  it('calls onClick handler when clicked', async () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+    await userEvent.click(screen.getByText('Click'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with all variant options without crashing', () => {
+    const { unmount: u1 } = render(<Button variant="primary">Primary</Button>);
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    u1();
+
+    const { unmount: u2 } = render(<Button variant="secondary">Secondary</Button>);
+    expect(screen.getByText('Secondary')).toBeInTheDocument();
+    u2();
+
+    render(<Button variant="outline">Outline</Button>);
+    expect(screen.getByText('Outline')).toBeInTheDocument();
+  });
+
+  it('renders with all size options without crashing', () => {
+    const { unmount: u1 } = render(<Button size="sm">Small</Button>);
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    u1();
+
+    const { unmount: u2 } = render(<Button size="md">Medium</Button>);
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    u2();
+
+    render(<Button size="lg">Large</Button>);
+    expect(screen.getByText('Large')).toBeInTheDocument();
+  });
+
+  it('passes through disabled attribute', () => {
+    render(<Button disabled>Go</Button>);
+    expect(screen.getByRole('button', { name: 'Go' })).toBeDisabled();
+  });
+
+  it('passes through type attribute', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button', { name: 'Submit' })).toHaveAttribute('type', 'submit');
+  });
+});

--- a/src/components/common/Card/Card.test.tsx
+++ b/src/components/common/Card/Card.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from 'test-utils';
+import Card from './index';
+
+describe('Card', () => {
+  it('renders children content', () => {
+    render(<Card><p>Hello</p></Card>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders an image when image prop is provided', () => {
+    render(<Card image="test.jpg" imageAlt="Test image">Content</Card>);
+    const img = screen.getByAltText('Test image');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'test.jpg');
+  });
+
+  it('does not render an image when image prop is omitted', () => {
+    render(<Card>Content</Card>);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('defaults imageAlt to empty string when not provided', () => {
+    const { container } = render(<Card image="test.jpg">Content</Card>);
+    const img = container.querySelector('img');
+    expect(img).toHaveAttribute('alt', '');
+  });
+});

--- a/src/components/common/Loader/Loader.test.tsx
+++ b/src/components/common/Loader/Loader.test.tsx
@@ -1,0 +1,14 @@
+import { render } from 'test-utils';
+import Loader from './index';
+
+describe('Loader', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Loader />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('contains a spinner element', () => {
+    const { container } = render(<Loader />);
+    expect(container.querySelectorAll('div').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/common/ScrollToTop.test.tsx
+++ b/src/components/common/ScrollToTop.test.tsx
@@ -1,0 +1,22 @@
+import { renderWithMemoryRouter } from 'test-utils';
+import ScrollToTop from './ScrollToTop';
+
+describe('ScrollToTop', () => {
+  beforeEach(() => {
+    jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls window.scrollTo(0, 0) on initial render', () => {
+    renderWithMemoryRouter(<ScrollToTop />);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('returns null (no visible UI)', () => {
+    const { container } = renderWithMemoryRouter(<ScrollToTop />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/components/common/SectionHeading/SectionHeading.test.tsx
+++ b/src/components/common/SectionHeading/SectionHeading.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from 'test-utils';
+import SectionHeading from './index';
+
+describe('SectionHeading', () => {
+  it('renders the title text', () => {
+    render(<SectionHeading title="Hello" />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle when provided', () => {
+    render(<SectionHeading title="Hello" subtitle="World" />);
+    expect(screen.getByText('World')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when omitted', () => {
+    render(<SectionHeading title="Hello" />);
+    expect(screen.queryByText('World')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/course/CourseCard/CourseCard.test.tsx
+++ b/src/components/course/CourseCard/CourseCard.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from 'test-utils';
+import CourseCard from './index';
+import { ICourse } from 'types';
+
+const mockTeacher = {
+  id: 't1',
+  name: 'Dr. Test Teacher',
+  designation: 'Professor',
+  department: 'medical' as const,
+  bio: 'Test bio',
+  avatar: 'https://example.com/avatar.jpg',
+};
+
+const mockCourse: ICourse = {
+  id: 'c1',
+  title: 'Test Course Title',
+  description: 'Test description',
+  category: 'medical',
+  thumbnail: 'https://example.com/thumb.jpg',
+  teacher: mockTeacher,
+  price: 2999,
+  originalPrice: 5999,
+  duration: '40 hours',
+  lessonsCount: 48,
+  studentsEnrolled: 1240,
+  rating: 4.8,
+  level: 'Beginner',
+};
+
+describe('CourseCard', () => {
+  beforeEach(() => {
+    render(<CourseCard course={mockCourse} />);
+  });
+
+  it('displays the course title', () => {
+    expect(screen.getByText('Test Course Title')).toBeInTheDocument();
+  });
+
+  it('displays the teacher name', () => {
+    expect(screen.getByText('Dr. Test Teacher')).toBeInTheDocument();
+  });
+
+  it('displays the course thumbnail with correct alt text', () => {
+    const img = screen.getByAltText('Test Course Title');
+    expect(img).toHaveAttribute('src', 'https://example.com/thumb.jpg');
+  });
+
+  it('displays the teacher avatar with correct alt text', () => {
+    const img = screen.getByAltText('Dr. Test Teacher');
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+
+  it('displays the category badge text', () => {
+    expect(screen.getByText('Medical')).toBeInTheDocument();
+  });
+
+  it('displays the formatted price in INR', () => {
+    expect(screen.getByText(/2,999/)).toBeInTheDocument();
+  });
+
+  it('displays the original price', () => {
+    expect(screen.getByText(/5,999/)).toBeInTheDocument();
+  });
+
+  it('displays course meta information', () => {
+    expect(screen.getByText('40 hours')).toBeInTheDocument();
+    expect(screen.getByText('48 lessons')).toBeInTheDocument();
+    expect(screen.getByText('Beginner')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Footer/Footer.test.tsx
+++ b/src/components/layout/Footer/Footer.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from 'test-utils';
+import Footer from './index';
+
+describe('Footer', () => {
+  beforeEach(() => {
+    render(<Footer />);
+  });
+
+  it('renders the brand name', () => {
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(/Medi/);
+  });
+
+  it('renders the brand tagline', () => {
+    expect(screen.getByText(/Bridging the gap/)).toBeInTheDocument();
+  });
+
+  it('renders Quick Links section', () => {
+    expect(screen.getByText('Quick Links')).toBeInTheDocument();
+  });
+
+  it('renders Categories section', () => {
+    expect(screen.getByText('Categories')).toBeInTheDocument();
+  });
+
+  it('renders Support section', () => {
+    expect(screen.getByText('Support')).toBeInTheDocument();
+  });
+
+  it('renders the copyright text with the current year', () => {
+    const year = new Date().getFullYear().toString();
+    expect(screen.getByText(new RegExp(year))).toBeInTheDocument();
+    expect(screen.getByText(/MediCode Institute/)).toBeInTheDocument();
+  });
+
+  it('renders footer links with href attributes', () => {
+    const links = screen.getAllByRole('link');
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('href');
+    });
+    expect(links.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/layout/Navbar/Navbar.test.tsx
+++ b/src/components/layout/Navbar/Navbar.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from 'test-utils';
+import userEvent from '@testing-library/user-event';
+import Navbar from './index';
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    render(<Navbar />);
+  });
+
+  it('renders the logo text', () => {
+    expect(screen.getByText(/Medi/)).toBeInTheDocument();
+    expect(screen.getByText(/Code/)).toBeInTheDocument();
+  });
+
+  it('renders all navigation links', () => {
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('All Courses')).toBeInTheDocument();
+    expect(screen.getByText('About')).toBeInTheDocument();
+    expect(screen.getByText('Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Blogs')).toBeInTheDocument();
+  });
+
+  it('renders navigation links with correct hrefs', () => {
+    expect(screen.getByText('Home').closest('a')).toHaveAttribute('href', '/');
+    expect(screen.getByText('All Courses').closest('a')).toHaveAttribute('href', '/courses');
+    expect(screen.getByText('About').closest('a')).toHaveAttribute('href', '/about');
+    expect(screen.getByText('Quiz').closest('a')).toHaveAttribute('href', '/quiz');
+    expect(screen.getByText('Blogs').closest('a')).toHaveAttribute('href', '/blogs');
+  });
+
+  it('renders the hamburger menu button', () => {
+    expect(screen.getByLabelText('Toggle menu')).toBeInTheDocument();
+  });
+
+  it('toggles mobile menu when hamburger is clicked', async () => {
+    const hamburger = screen.getByLabelText('Toggle menu');
+    await userEvent.click(hamburger);
+    // The component should not crash after toggling
+    expect(hamburger).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/PageWrapper/PageWrapper.test.tsx
+++ b/src/components/layout/PageWrapper/PageWrapper.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from 'test-utils';
+import PageWrapper from './index';
+
+describe('PageWrapper', () => {
+  it('renders children content', () => {
+    render(<PageWrapper><p>Child content</p></PageWrapper>);
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+});

--- a/src/pages/About/About.test.tsx
+++ b/src/pages/About/About.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from 'test-utils';
+import About from './index';
+
+describe('About', () => {
+  beforeEach(() => {
+    render(<About />);
+  });
+
+  it('renders the page heading', () => {
+    expect(screen.getByText('About MediCode Institute')).toBeInTheDocument();
+  });
+
+  it('renders the Mission section', () => {
+    expect(screen.getByText('Our Mission')).toBeInTheDocument();
+    expect(screen.getByText(/bridge the gap/)).toBeInTheDocument();
+  });
+
+  it('renders the Vision section', () => {
+    expect(screen.getByText('Our Vision')).toBeInTheDocument();
+  });
+
+  it('renders the What We Offer section with all 4 offerings', () => {
+    expect(screen.getByText('Medical Courses')).toBeInTheDocument();
+    expect(screen.getByText('CS Courses')).toBeInTheDocument();
+    expect(screen.getByText('Interactive Quizzes')).toBeInTheDocument();
+    expect(screen.getByText('Live Sessions')).toBeInTheDocument();
+  });
+
+  it('renders all 4 teacher cards', () => {
+    expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument();
+    expect(screen.getByText('Dr. Rajesh Verma')).toBeInTheDocument();
+    expect(screen.getByText('Ankit Patel')).toBeInTheDocument();
+    expect(screen.getByText('Sneha Gupta')).toBeInTheDocument();
+  });
+
+  it('renders the contact section', () => {
+    expect(screen.getByText('Get in Touch')).toBeInTheDocument();
+    expect(screen.getByText('contact@medicode.in')).toBeInTheDocument();
+  });
+});

--- a/src/pages/About/TeacherCard.test.tsx
+++ b/src/pages/About/TeacherCard.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from 'test-utils';
+import TeacherCard from './TeacherCard';
+import { ITeacher } from 'types';
+
+const mockTeacher: ITeacher = {
+  id: 't1',
+  name: 'Dr. Test Name',
+  designation: 'Senior Professor',
+  department: 'medical',
+  bio: 'A detailed bio about the teacher.',
+  avatar: 'https://example.com/avatar.jpg',
+};
+
+describe('TeacherCard', () => {
+  beforeEach(() => {
+    render(<TeacherCard teacher={mockTeacher} />);
+  });
+
+  it('renders teacher name', () => {
+    expect(screen.getByText('Dr. Test Name')).toBeInTheDocument();
+  });
+
+  it('renders teacher designation', () => {
+    expect(screen.getByText('Senior Professor')).toBeInTheDocument();
+  });
+
+  it('renders teacher avatar with correct alt text', () => {
+    const img = screen.getByAltText('Dr. Test Name avatar');
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+
+  it('renders department badge', () => {
+    expect(screen.getByText('Medical')).toBeInTheDocument();
+  });
+
+  it('renders teacher bio', () => {
+    expect(screen.getByText('A detailed bio about the teacher.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Blog/Blog.test.tsx
+++ b/src/pages/Blog/Blog.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from 'test-utils';
+import userEvent from '@testing-library/user-event';
+import Blog from './index';
+
+describe('Blog', () => {
+  beforeEach(() => {
+    render(<Blog />);
+  });
+
+  it('renders the page heading', () => {
+    expect(screen.getByText('Blog & Articles')).toBeInTheDocument();
+  });
+
+  it('renders all filter tabs', () => {
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Medical')).toBeInTheDocument();
+    expect(screen.getByText('CS')).toBeInTheDocument();
+    expect(screen.getByText('General')).toBeInTheDocument();
+  });
+
+  it('shows all 5 blog cards by default', () => {
+    expect(screen.getByText('How to Prepare for NEET PG 2026: A Complete Guide')).toBeInTheDocument();
+    expect(screen.getByText(/Understanding ECG/)).toBeInTheDocument();
+    expect(screen.getByText("React 19: What's New and How to Migrate")).toBeInTheDocument();
+    expect(screen.getByText('Top 10 DSA Patterns for Coding Interviews')).toBeInTheDocument();
+    expect(screen.getByText('Why Every Medical Student Should Learn to Code')).toBeInTheDocument();
+  });
+
+  it('displays blog author and read time', () => {
+    expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument();
+    expect(screen.getByText('8 min read')).toBeInTheDocument();
+  });
+
+  it('displays formatted dates', () => {
+    expect(screen.getByText(/15 January 2026|January 15, 2026/)).toBeInTheDocument();
+  });
+
+  it('filters to medical blogs when Medical tab is clicked', async () => {
+    await userEvent.click(screen.getByText('Medical'));
+    expect(screen.getByText('How to Prepare for NEET PG 2026: A Complete Guide')).toBeInTheDocument();
+    expect(screen.getByText(/Understanding ECG/)).toBeInTheDocument();
+    expect(screen.queryByText("React 19: What's New and How to Migrate")).not.toBeInTheDocument();
+  });
+
+  it('filters to CS blogs when CS tab is clicked', async () => {
+    await userEvent.click(screen.getByText('CS'));
+    expect(screen.getByText("React 19: What's New and How to Migrate")).toBeInTheDocument();
+    expect(screen.getByText('Top 10 DSA Patterns for Coding Interviews')).toBeInTheDocument();
+    expect(screen.queryByText('How to Prepare for NEET PG 2026: A Complete Guide')).not.toBeInTheDocument();
+  });
+
+  it('filters to general blogs when General tab is clicked', async () => {
+    await userEvent.click(screen.getByText('General'));
+    expect(screen.getByText(/Why Every Medical Student Should Learn to Code/)).toBeInTheDocument();
+    expect(screen.queryByText('How to Prepare for NEET PG 2026: A Complete Guide')).not.toBeInTheDocument();
+  });
+
+  it('renders Read More link for each blog', () => {
+    const readMoreLinks = screen.getAllByText(/Read More/);
+    expect(readMoreLinks.length).toBe(5);
+  });
+});

--- a/src/pages/Courses/Courses.test.tsx
+++ b/src/pages/Courses/Courses.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from 'test-utils';
+import userEvent from '@testing-library/user-event';
+import Courses from './index';
+
+describe('Courses', () => {
+  beforeEach(() => {
+    render(<Courses />);
+  });
+
+  it('renders the page heading', () => {
+    expect(screen.getByText('All Courses')).toBeInTheDocument();
+  });
+
+  it('renders all filter tabs', () => {
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Medical' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CS' })).toBeInTheDocument();
+  });
+
+  it('shows all 6 courses by default', () => {
+    expect(screen.getByText('Complete Human Anatomy')).toBeInTheDocument();
+    expect(screen.getByText('Clinical Cardiology Essentials')).toBeInTheDocument();
+    expect(screen.getByText('Pharmacology Made Easy')).toBeInTheDocument();
+    expect(screen.getByText('React & TypeScript Masterclass')).toBeInTheDocument();
+    expect(screen.getByText('Data Structures & Algorithms')).toBeInTheDocument();
+    expect(screen.getByText('Machine Learning with Python')).toBeInTheDocument();
+  });
+
+  it('filters to only medical courses when Medical tab is clicked', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Medical' }));
+    expect(screen.getByText('Complete Human Anatomy')).toBeInTheDocument();
+    expect(screen.getByText('Clinical Cardiology Essentials')).toBeInTheDocument();
+    expect(screen.getByText('Pharmacology Made Easy')).toBeInTheDocument();
+    expect(screen.queryByText('React & TypeScript Masterclass')).not.toBeInTheDocument();
+    expect(screen.queryByText('Data Structures & Algorithms')).not.toBeInTheDocument();
+  });
+
+  it('filters to only CS courses when CS tab is clicked', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'CS' }));
+    expect(screen.getByText('React & TypeScript Masterclass')).toBeInTheDocument();
+    expect(screen.getByText('Data Structures & Algorithms')).toBeInTheDocument();
+    expect(screen.getByText('Machine Learning with Python')).toBeInTheDocument();
+    expect(screen.queryByText('Complete Human Anatomy')).not.toBeInTheDocument();
+  });
+
+  it('shows all courses again when All tab is clicked after filtering', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Medical' }));
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('Complete Human Anatomy')).toBeInTheDocument();
+    expect(screen.getByText('React & TypeScript Masterclass')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Home/Home.test.tsx
+++ b/src/pages/Home/Home.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from 'test-utils';
+import Home from './index';
+
+describe('Home', () => {
+  beforeEach(() => {
+    render(<Home />);
+  });
+
+  it('renders the HeroSection with headline', () => {
+    expect(screen.getByText('Bridge Medicine & Technology')).toBeInTheDocument();
+  });
+
+  it('renders the hero CTA button', () => {
+    expect(screen.getByText('Explore Courses')).toBeInTheDocument();
+  });
+
+  it('renders the FeaturesSection with all 4 features', () => {
+    expect(screen.getByText('Expert Faculty')).toBeInTheDocument();
+    expect(screen.getByText('Interactive Quizzes')).toBeInTheDocument();
+    expect(screen.getByText('Flexible Learning')).toBeInTheDocument();
+    expect(screen.getByText('Dual Curriculum')).toBeInTheDocument();
+  });
+
+  it('renders the Popular Courses section heading', () => {
+    expect(screen.getByText('Popular Courses')).toBeInTheDocument();
+  });
+
+  it('renders exactly 3 popular course cards', () => {
+    expect(screen.getByText('Complete Human Anatomy')).toBeInTheDocument();
+    expect(screen.getByText('Clinical Cardiology Essentials')).toBeInTheDocument();
+    expect(screen.getByText('Pharmacology Made Easy')).toBeInTheDocument();
+  });
+
+  it('renders the Explore Categories section', () => {
+    expect(screen.getByText('Medical Sciences')).toBeInTheDocument();
+    expect(screen.getByText('Computer Science')).toBeInTheDocument();
+  });
+
+  it('renders the StatsSection with stat values', () => {
+    expect(screen.getByText('10,000+')).toBeInTheDocument();
+    expect(screen.getByText('50+')).toBeInTheDocument();
+    expect(screen.getByText('20+')).toBeInTheDocument();
+    expect(screen.getByText('95%')).toBeInTheDocument();
+  });
+
+  it('renders the CTA section', () => {
+    expect(screen.getByText('Start Your Learning Journey Today')).toBeInTheDocument();
+  });
+
+  it('renders the View All Courses link', () => {
+    expect(screen.getByText('View All Courses')).toBeInTheDocument();
+  });
+});

--- a/src/pages/NotFound/NotFound.test.tsx
+++ b/src/pages/NotFound/NotFound.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from 'test-utils';
+import NotFound from './index';
+
+describe('NotFound', () => {
+  beforeEach(() => {
+    render(<NotFound />);
+  });
+
+  it('renders the 404 error code', () => {
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('renders the Page Not Found heading', () => {
+    expect(screen.getByText('Page Not Found')).toBeInTheDocument();
+  });
+
+  it('renders a descriptive subtitle', () => {
+    expect(screen.getByText(/doesn't exist or has been moved/)).toBeInTheDocument();
+  });
+
+  it('renders a link to the home page', () => {
+    const link = screen.getByText('Go Home').closest('a');
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/src/pages/Quiz/Quiz.test.tsx
+++ b/src/pages/Quiz/Quiz.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from 'test-utils';
+import Quiz from './index';
+
+describe('Quiz', () => {
+  beforeEach(() => {
+    render(<Quiz />);
+  });
+
+  it('renders the page heading', () => {
+    expect(screen.getByText('Practice Quizzes')).toBeInTheDocument();
+  });
+
+  it('renders all 4 quiz cards with their titles', () => {
+    expect(screen.getByText('Human Anatomy Basics')).toBeInTheDocument();
+    expect(screen.getByText('Pharmacology Fundamentals')).toBeInTheDocument();
+    expect(screen.getByText('JavaScript Fundamentals')).toBeInTheDocument();
+    expect(screen.getByText('Data Structures Challenge')).toBeInTheDocument();
+  });
+
+  it('renders category badges', () => {
+    const medicalBadges = screen.getAllByText('Medical');
+    const csBadges = screen.getAllByText('CS');
+    expect(medicalBadges.length).toBe(2);
+    expect(csBadges.length).toBe(2);
+  });
+
+  it('renders difficulty badges', () => {
+    expect(screen.getAllByText('Easy').length).toBe(2);
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('Hard')).toBeInTheDocument();
+  });
+
+  it('renders quiz meta info', () => {
+    const questionCounts = screen.getAllByText('5 questions');
+    expect(questionCounts.length).toBe(4);
+    expect(screen.getAllByText('10 min').length).toBe(3);
+    expect(screen.getByText('15 min')).toBeInTheDocument();
+  });
+
+  it('renders Start Quiz buttons', () => {
+    const buttons = screen.getAllByText('Start Quiz');
+    expect(buttons.length).toBe(4);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,5 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextEncoder, TextDecoder });
+
+import '@testing-library/jest-dom';

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import theme from 'styles/theme';
+
+const AllProviders: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <BrowserRouter>{children}</BrowserRouter>
+  </ThemeProvider>
+);
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: AllProviders, ...options });
+
+export const renderWithMemoryRouter = (
+  ui: ReactElement,
+  { initialEntries = ['/'], ...options }: Omit<RenderOptions, 'wrapper'> & { initialEntries?: string[] } = {}
+) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </ThemeProvider>,
+    options
+  );
+
+export * from '@testing-library/react';
+export { customRender as render };

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,0 +1,51 @@
+import { formatPrice, formatDate, truncateText } from './helpers';
+
+describe('formatPrice', () => {
+  it('formats a round number in INR without decimals', () => {
+    const result = formatPrice(2999);
+    expect(result).toContain('2,999');
+  });
+
+  it('formats zero as INR', () => {
+    const result = formatPrice(0);
+    expect(result).toContain('0');
+  });
+
+  it('formats large numbers with Indian grouping', () => {
+    const result = formatPrice(100000);
+    expect(result).toContain('1,00,000');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats an ISO date string to long format', () => {
+    const result = formatDate('2026-01-15');
+    expect(result).toContain('January');
+    expect(result).toContain('2026');
+    expect(result).toContain('15');
+  });
+
+  it('handles another date correctly', () => {
+    const result = formatDate('2026-02-10');
+    expect(result).toContain('February');
+    expect(result).toContain('2026');
+  });
+});
+
+describe('truncateText', () => {
+  it('returns text unchanged when shorter than maxLength', () => {
+    expect(truncateText('hello', 10)).toBe('hello');
+  });
+
+  it('truncates and appends ellipsis when text exceeds maxLength', () => {
+    expect(truncateText('hello world', 5)).toBe('hello...');
+  });
+
+  it('handles exact boundary length', () => {
+    expect(truncateText('hello', 5)).toBe('hello');
+  });
+
+  it('trims trailing whitespace before adding ellipsis', () => {
+    expect(truncateText('hello world', 6)).toBe('hello...');
+  });
+});


### PR DESCRIPTION
- Add shared test utility (test-utils.tsx) with ThemeProvider + BrowserRouter wrappers
- Add setupTests.ts with jest-dom matchers and TextEncoder polyfill
- Add Jest moduleNameMapper for react-router-dom v7 compatibility
- Add tests for common components: Button, Card, Loader, SectionHeading, ScrollToTop
- Add tests for layout components: Navbar, Footer, PageWrapper
- Add tests for CourseCard component
- Add tests for all pages: Home, Courses, Quiz, Blog, About, NotFound
- Add unit tests for utility functions: formatPrice, formatDate, truncateText
- Update CLAUDE.md with branch-from-main rule
- 99 tests across 18 test suites, all passing